### PR TITLE
Feature/update to hop client 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ python = ">=3.8,<3.12"
 tomtoolkit = "^2.10"
 psycopg2-binary = "^2.9"
 gcn-kafka = "^0.2"
-hop-client = "^0.7"
+hop-client = "^0.8"
 
 [tool.poetry.dev-dependencies]
 coverage = "^6.3.2"

--- a/tom_alertstreams/alertstreams/hopskotch.py
+++ b/tom_alertstreams/alertstreams/hopskotch.py
@@ -14,7 +14,7 @@ from hop.io import Metadata, StartPosition, list_topics
 from tom_alertstreams.alertstreams.alertstream import AlertStream
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+#logger.setLevel(logging.DEBUG)
 
 
 class HopskotchAlertStream(AlertStream):
@@ -96,15 +96,13 @@ class HopskotchAlertStream(AlertStream):
 
     def listen(self):
         super().listen()
-        # TODO: Provide example of making this a collections.defaultdict with a
-        # default_factory which handles unexpected topics nicely.
-
         # TODO: alternatively, WARN upon OPTIONS['topics'] extries that don't have
         # handlers in the alert_handler. (i.e they've configured a topic subscription
         # without providing a handler for the topic. So, warn them).
         last_check_time = tz.now()
         while True:
             try:
+                logger.info(f'HopskotchAlertStream.listen opening stream: {self.stream_url} with group_id: {self.group_id}')
                 with self.stream.open(self.stream_url, 'r', group_id=self.group_id) as src:
                     for alert, metadata in src.read(metadata=True):
                         # type(gcn_circular) is <hop.models.GNCCircular>
@@ -160,5 +158,6 @@ def alert_logger(alert: JSONBlob, metadata: Metadata):
     if alert_uuid_tuple:
         alert_uuid = uuid.UUID(bytes=alert_uuid_tuple[1])
     else:
+        # in this case the alert was probably published with hop-client<0.8.0
         alert_uuid = None
     logger.info(f'Alert (uuid={alert_uuid}) received on topic {metadata.topic}: {alert};  metatdata: {metadata}')

--- a/tom_alertstreams/alertstreams/hopskotch.py
+++ b/tom_alertstreams/alertstreams/hopskotch.py
@@ -122,7 +122,7 @@ class HopskotchAlertStream(AlertStream):
                             if not matched_handler:
                                 self.alert_handler['*'](alert, metadata)
                         else:
-                            logger.error(f'alert from topic {metadata.topic} received but no handler defined. err: {err}')
+                            logger.error(f'alert from topic {metadata.topic} received but no handler defined.')
                             # TODO: should define a default handler for all unhandeled topics
                         if (tz.now() - last_check_time).total_seconds() > self.PUBLIC_TOPIC_CHECK_INTERVAL:
                             last_check_time = tz.now()
@@ -133,7 +133,7 @@ class HopskotchAlertStream(AlertStream):
                                 self.stream_url = self.get_stream_url()
                                 break
             except Exception as ex:
-                logger.error(ex)
+                logger.error(f'HopskotchAlertStream.listen: {ex}')
 
 def heartbeat_handler(heartbeat: JSONBlob, metadata: Metadata):
     """Example alert handler for HopskotchAlertStream sys.heartbeat topic.

--- a/tom_alertstreams/alertstreams/hopskotch.py
+++ b/tom_alertstreams/alertstreams/hopskotch.py
@@ -18,7 +18,7 @@ logger.setLevel(logging.DEBUG)
 class HopskotchAlertStream(AlertStream):
     """
     """
-    required_keys = ['URL', 'USERNAME', 'PASSWORD', 'TOPIC_HANDLERS']
+    required_keys = ['URL', 'GROUP_ID', 'USERNAME', 'PASSWORD', 'TOPIC_HANDLERS']
     allowed_keys = ['URL', 'GROUP_ID', 'USERNAME', 'PASSWORD', 'TOPIC_HANDLERS']
     PUBLIC_TOPIC_CHECK_INTERVAL = 300  # Seconds between checking for new public topics
     def __init__(self, *args, **kwargs) -> None:

--- a/tom_alertstreams/alertstreams/hopskotch.py
+++ b/tom_alertstreams/alertstreams/hopskotch.py
@@ -1,6 +1,8 @@
 from datetime import datetime, timezone
 import logging
 import re
+import uuid
+
 from django.utils import timezone as tz
 from django.core.exceptions import ImproperlyConfigured
 

--- a/tom_alertstreams/alertstreams/hopskotch.py
+++ b/tom_alertstreams/alertstreams/hopskotch.py
@@ -77,7 +77,7 @@ class HopskotchAlertStream(AlertStream):
             # Add all public topics if a asterisk is set in the topic_handlers
             specified_topics = list(set(specified_topics + self.public_topics))
         # Also remove topics with wildcards in them
-        specified_topics = [topic for topic in specified_topics if '*' in topic]
+        specified_topics = [topic for topic in specified_topics if not '*' in topic]
 
         topics = ','.join(specified_topics)  # 'topic1,topic2,topic3'
         hopskotch_stream_url = base_stream_url + topics
@@ -124,7 +124,7 @@ class HopskotchAlertStream(AlertStream):
                         else:
                             logger.error(f'alert from topic {metadata.topic} received but no handler defined. err: {err}')
                             # TODO: should define a default handler for all unhandeled topics
-                        if (tz.now - last_check_time).total_seconds() > self.PUBLIC_TOPIC_CHECK_INTERVAL:
+                        if (tz.now() - last_check_time).total_seconds() > self.PUBLIC_TOPIC_CHECK_INTERVAL:
                             last_check_time = tz.now()
                             public_topics = self.get_all_public_topics()
                             if set(public_topics) != set(self.public_topics):

--- a/tom_alertstreams/alertstreams/hopskotch.py
+++ b/tom_alertstreams/alertstreams/hopskotch.py
@@ -152,4 +152,11 @@ def heartbeat_handler(heartbeat: JSONBlob, metadata: Metadata):
 def alert_logger(alert: JSONBlob, metadata: Metadata):
     """Example alert handler. The method signsture is specific to Hopskotch alerts.
     """
-    logger.info(f'Alert received on topic {metadata.topic}: {alert};  metatdata: {metadata}')
+    # search the header (list of tuples) for a UUID-tuple (keyed by '_id')
+    # eg. ('_id', b'$\xd6oGmVM\xed\x97\xe7|\x1c\x8f\x11V\xe9')
+    alert_uuid_tuple = next((item for item in metadata.headers if item[0] == '_id'), None)
+    if alert_uuid_tuple:
+        alert_uuid = uuid.UUID(bytes=alert_uuid_tuple[1])
+    else:
+        alert_uuid = None
+    logger.info(f'Alert (uuid={alert_uuid}) received on topic {metadata.topic}: {alert};  metatdata: {metadata}')

--- a/tom_alertstreams/management/commands/hoptestpub.py
+++ b/tom_alertstreams/management/commands/hoptestpub.py
@@ -1,0 +1,40 @@
+import datetime
+import logging
+
+from django.core.exceptions import ImproperlyConfigured
+from django.core.management.base import BaseCommand
+
+from tom_alertstreams.alertstreams.alertstream import get_default_alert_streams
+from tom_alertstreams.alertstreams.hopskotch import HopskotchAlertStream
+
+logger = logging.getLogger(__name__)
+# logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
+
+
+class Command(BaseCommand):
+    help = 'Publish a timestamped test message to Hopskotch tomtoolkit.test topic.'
+
+    def handle(self, *args, **options):
+        logger.debug(f'hoptestpub.Command.handle() args: {args}')
+        logger.debug(f'hoptestpub.Command.handle() options: {options}')
+
+        try:
+            alert_streams = get_default_alert_streams()
+            # extract the HopskotchAlertStream
+            hopskotch_alert_stream = next(stream for stream in alert_streams if isinstance(stream, HopskotchAlertStream))
+
+        except ImproperlyConfigured as ex:
+            logger.error(f'{ex.__class__.__name__}: Configure alert streams in settings.py ALERT_STREAMS: {ex}')
+            exit(1)
+
+        stream = hopskotch_alert_stream.get_stream()
+        topic = 'tomtoolkit.test'  # SCiMMA Admin topic permissions for Credential are assumed to have been set up
+
+        with stream.open(hopskotch_alert_stream.url+topic, "w") as s:
+            s.write({
+                'created': datetime.datetime.utcnow().isoformat(),
+                'created-by': 'tom-alertstreams hoptestpub.py'
+             })
+
+        logger.info('hoptestpub Command.handle() returning...')

--- a/tom_alertstreams_base/settings.py
+++ b/tom_alertstreams_base/settings.py
@@ -162,6 +162,7 @@ ALERT_STREAMS = [
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', None),
             'TOPIC_HANDLERS': {
                 'sys.heartbeat': 'tom_alertstreams.alertstreams.hopskotch.heartbeat_handler',
+                'sys.heartbeatnew': 'tom_alertstreams.alertstreams.hopskotch.heartbeat_handler',
                 'tomtoolkit.test': 'tom_alertstreams.alertstreams.hopskotch.alert_logger',
                 'hermes.test': 'tom_alertstreams.alertstreams.hopskotch.alert_logger',
             },

--- a/tom_alertstreams_base/settings.py
+++ b/tom_alertstreams_base/settings.py
@@ -157,6 +157,8 @@ ALERT_STREAMS = [
         'ACTIVE': True,
         'NAME': 'tom_alertstreams.alertstreams.hopskotch.HopskotchAlertStream',
         'OPTIONS': {
+            # The hop-client requires that the GROUP_ID prefix match the SCIMMA_AUTH_USERNAME
+            'GROUP_ID': os.getenv('SCIMMA_AUTH_USERNAME', "") + '-' + os.getenv('HOPSKOTCH_GROUP_ID', 'tom-alertstreams-dev'),
             'URL': 'kafka://kafka.scimma.org/',
             'USERNAME': os.getenv('SCIMMA_AUTH_USERNAME', None),
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', None),


### PR DESCRIPTION
* Updates hop-client to 0.8.0 which has UUIDs in alert metadata headers.
* Adds example of extracting UUID from alert metadata header in `hopskotch` `alert_logger`
* enforces `hop-client` requirement that Kafka consumer group_id be prefixed with SCiMMA Auth SCRAM cred username
* A bug/typo fix for handling wildcard topics