### PR TITLE
Draft PR: add logger for igwn.gwalert topic; brings fastavro dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ tomtoolkit = "^2.10"
 psycopg2-binary = "^2.9"
 gcn-kafka = "^0.2"
 hop-client = "^0.8"
+fastavro = "^1.0"
 
 [tool.poetry.dev-dependencies]
 coverage = "^6.3.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Django~=4.1
 psycopg2-binary~=2.9
 gcn-kafka~=0.2
 hop-client~=0.8
+fastavro~=1.0

--- a/tom_alertstreams_base/settings.py
+++ b/tom_alertstreams_base/settings.py
@@ -12,6 +12,7 @@ https://docs.djangoproject.com/en/4.1/ref/settings/
 import logging.config
 import os
 from pathlib import Path
+import datetime
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -158,15 +159,18 @@ ALERT_STREAMS = [
         'NAME': 'tom_alertstreams.alertstreams.hopskotch.HopskotchAlertStream',
         'OPTIONS': {
             # The hop-client requires that the GROUP_ID prefix match the SCIMMA_AUTH_USERNAME
-            'GROUP_ID': os.getenv('SCIMMA_AUTH_USERNAME', "") + '-' + os.getenv('HOPSKOTCH_GROUP_ID', 'tom-alertstreams-dev'),
+            'GROUP_ID': os.getenv('SCIMMA_AUTH_USERNAME', "") + '-' +
+                        os.getenv('HOPSKOTCH_GROUP_ID', 'tom-alertstreams-dev') + '-' +
+                        f'{datetime.datetime.now().microsecond}',
             'URL': 'kafka://kafka.scimma.org/',
             'USERNAME': os.getenv('SCIMMA_AUTH_USERNAME', None),
             'PASSWORD': os.getenv('SCIMMA_AUTH_PASSWORD', None),
             'TOPIC_HANDLERS': {
-                'sys.heartbeat': 'tom_alertstreams.alertstreams.hopskotch.heartbeat_handler',
-                'sys.heartbeatnew': 'tom_alertstreams.alertstreams.hopskotch.heartbeat_handler',
+                #'sys.heartbeat': 'tom_alertstreams.alertstreams.hopskotch.heartbeat_handler',
+                #'sys.heartbeatnew': 'tom_alertstreams.alertstreams.hopskotch.heartbeat_handler',
                 'tomtoolkit.test': 'tom_alertstreams.alertstreams.hopskotch.alert_logger',
                 'hermes.test': 'tom_alertstreams.alertstreams.hopskotch.alert_logger',
+                #'igwn.gwalert': 'tom_alertstreams.alertstreams.hopskotch.igwn_alert_logger',
             },
         },
     },


### PR DESCRIPTION
this is a prototype. In production, Hermes is subscribing to the equivalent GCNClassicOverKafka topics. For more info/docs, see https://emfollow.docs.ligo.org/userguide/tutorial/receiving/scimma.html#receiving-and-parsing-notices and some public talk slides:
https://dcc.ligo.org/LIGO-G2202193/public

I'm parking these commits here, but it's not clear to me that they need to be merged.